### PR TITLE
Feature/add duration and ip

### DIFF
--- a/webhook_logs.go
+++ b/webhook_logs.go
@@ -39,8 +39,8 @@ type Log struct {
 	ResponseHeaders Headers       `json:"response_headers" `
 	Status          RequestStatus `json:"status"`
 	Retries         int           `json:"retries"`
-
-	IPAddress string `json:"ip_address"`
+	DurationMs      uint64        `json:"duration_ms"`
+	IPAddress       string        `json:"ip_address"`
 
 	// request details
 	Headers   Headers `json:"headers"`

--- a/webhook_logs.go
+++ b/webhook_logs.go
@@ -40,6 +40,8 @@ type Log struct {
 	Status          RequestStatus `json:"status"`
 	Retries         int           `json:"retries"`
 
+	IPAddress string `json:"ip_address"`
+
 	// request details
 	Headers   Headers `json:"headers"`
 	RawQuery  string  `json:"raw_query"`
@@ -191,6 +193,7 @@ type WebhookLogsUpdateRequest struct {
 	ResponseHeaders Headers       `json:"response_headers" `
 	Status          RequestStatus `json:"status"`
 	Retries         int           `json:"retries"`
+	DurationMs      uint64        `json:"duration_ms"`
 }
 
 // UpdateWebhookLog - update webhook log response body, headers and status code.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds new metadata to webhook logs and update payloads.
> 
> - Extends `Log` with `duration_ms` and `ip_address` fields for timing and source tracking
> - Extends `WebhookLogsUpdateRequest` with `duration_ms` to allow updating duration alongside response data
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89d3143edc12104ee6113f3f85975f8ce8617193. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->