### PR TITLE
docs: feature-focused README + fix ListWebhookLogs filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
-# Webhook Relay API Go client
+# Webhook Relay Go client
 
-[![GoDoc](https://img.shields.io/badge/godoc-reference-5673AF.svg?style=flat-square)](https://godoc.org/github.com/webhookrelay/webhookrelay-go)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-5673AF.svg?style=flat-square)](https://pkg.go.dev/github.com/webhookrelay/webhookrelay-go)
+[![Tests](https://github.com/webhookrelay/webhookrelay-go/actions/workflows/test.yml/badge.svg)](https://github.com/webhookrelay/webhookrelay-go/actions/workflows/test.yml)
 
-> This library is currently actively developed so the API might change a little bit.
+Go client for the [Webhook Relay](https://webhookrelay.com) v1 API.
+
+Webhook Relay receives webhooks and HTTP requests on a public endpoint and delivers
+them wherever you need — public URLs, services **behind a firewall or on localhost**,
+**WebSocket** clients, or on a **schedule** — with in-flight **transformations**,
+**durable retries**, **throttling** and fine-grained routing. This library configures
+all of it from Go.
 
 ## Installation
-
-You need a working [Go](https://golang.org/) environment. 
 
 ```shell
 go get github.com/webhookrelay/webhookrelay-go
 ```
+
+Requires a working [Go](https://golang.org/) environment (Go 1.23+).
 
 ## Authentication
 
@@ -18,19 +25,22 @@ Generate credentials [here](https://my.webhookrelay.com/tokens). There are two w
 
 - **API key (recommended)** — a single key (looks like `sk-...`) sent as a Bearer token:
 
-  ```golang
+  ```go
   api, err := webhookrelay.NewWithAPIKey(os.Getenv("RELAY_API_KEY"))
   ```
 
 - **Key & secret pair** — sent as HTTP Basic auth:
 
-  ```golang
+  ```go
   api, err := webhookrelay.New(os.Getenv("RELAY_KEY"), os.Getenv("RELAY_SECRET"))
   ```
 
-## Usage
+## Quickstart
 
-```golang
+Create a bucket (which comes with a ready-to-use public input endpoint) and forward
+everything it receives to a destination:
+
+```go
 package main
 
 import (
@@ -42,39 +52,189 @@ import (
 )
 
 func main() {
-	// Construct a new Webhook Relay API object to perform requests. Use an API
-	// key (Bearer token); alternatively use webhookrelay.New(key, secret).
 	api, err := webhookrelay.NewWithAPIKey(os.Getenv("RELAY_API_KEY"))
 	if err != nil {
 		log.Fatal(err)
-  }
-  
-  bucket, err := api.CreateBucket(&webhookrelay.BucketCreateOptions{
-    Name: "sendgrid-to-segment",
-  })
-  if err != nil {
-		log.Fatal(err)
-  }
-  // all buckets get a default input that you can use to receive webhooks, 
-  // it can either be used with custom domain + path prefix (https://xxx.hooks.webhookrelay.com) 
-  // or input ID such as https://my.webhookrelay.com/v1/webhooks/xxx
-  fmt.Println(bucket.Inputs[0].EndpointURL()) 
+	}
 
-  // Create a webhook forwarding destination for this webhook
-  _, err = api.CreateOutput(&webhookrelay.Output{
-    BucketID: bucket.ID,
-    Name: "segment",
-    Destination: "https://webhooks.segment.com?b=yyyy",
-  })
-  if err != nil {
+	// A bucket groups an input (public URL) with one or more outputs (destinations).
+	bucket, err := api.CreateBucket(&webhookrelay.BucketCreateOptions{
+		Name: "sendgrid-to-segment",
+	})
+	if err != nil {
 		log.Fatal(err)
-  }
+	}
 
-  // list all buckets
-  buckets, err := api.ListBuckets(&webhookrelay.BucketListOptions{})
-  if err != nil {
+	// Every bucket gets a default input. Point your webhook provider at this URL:
+	fmt.Println("Send webhooks to:", bucket.Inputs[0].EndpointURL())
+
+	// Forward everything the bucket receives to a public destination.
+	if _, err := api.CreateOutput(&webhookrelay.Output{
+		BucketID:    bucket.ID,
+		Name:        "segment",
+		Destination: "https://webhooks.segment.com?b=yyyy",
+	}); err != nil {
 		log.Fatal(err)
-  }
-  fmt.Println(buckets) // print buckets
+	}
 }
 ```
+
+## Features
+
+### Internal webhooks — deliver behind a firewall
+
+Mark an output as `Internal` (or just point it at a private/localhost address) and
+it will only be delivered by the [`relay`](https://webhookrelay.com/v1/installation/)
+agent running inside your network. This lets an external provider reach a service
+that has no public IP.
+
+```go
+// Public providers deliver to bucket.Inputs[0].EndpointURL(); the agent picks the
+// webhooks up and forwards them to your internal service.
+_, err = api.CreateOutput(&webhookrelay.Output{
+	BucketID:    bucket.ID,
+	Name:        "local-dev",
+	Destination: "http://localhost:8080/webhooks",
+	Internal:    true, // relayed by the agent, not the public forwarder
+})
+```
+
+Then run the agent to open the connection:
+
+```shell
+relay forward --bucket sendgrid-to-segment http://localhost:8080/webhooks
+```
+
+### WebSocket streaming
+
+Enable streaming on a bucket to receive its webhooks in real time over a WebSocket
+(`wss://my.webhookrelay.com/v1/socket`) — handy for browsers, dashboards, or any
+client that can't expose an endpoint.
+
+```go
+bucket, err := api.GetBucket("sendgrid-to-segment")
+if err != nil {
+	log.Fatal(err)
+}
+bucket.Stream = true
+if _, err := api.UpdateBucket(bucket); err != nil {
+	log.Fatal(err)
+}
+```
+
+When acting as a WebSocket "transponder" (your client, not Webhook Relay, produces
+the HTTP response), send the response back within 10 seconds using `UpdateWebhookLog`:
+
+```go
+err = api.UpdateWebhookLog(&webhookrelay.WebhookLogsUpdateRequest{
+	ID:         logID, // the webhook's log ID, received over the socket
+	StatusCode: 200,
+	Status:     webhookrelay.RequestStatusSent,
+	ResponseBody: []byte(`{"ok":true}`),
+})
+```
+
+### Polling for webhooks
+
+Prefer to pull instead of being pushed? Poll a bucket's logs and process new
+webhooks yourself. `BucketID` is required; filter by status, time range and paginate.
+
+```go
+res, err := api.ListWebhookLogs(&webhookrelay.WebhookLogsListOptions{
+	BucketID: bucket.ID,
+	Status:   webhookrelay.RequestStatusReceived,
+	Limit:    50,
+})
+if err != nil {
+	log.Fatal(err)
+}
+for _, entry := range res.Data {
+	fmt.Printf("%s %s -> %d\n", entry.Method, entry.ID, entry.StatusCode)
+	// entry.Body, entry.Headers, entry.RawQuery ...
+}
+```
+
+### Durable delivery
+
+If a destination is down, durable delivery persists failing webhooks and keeps
+retrying on a backoff schedule until they succeed or hit a deadline — so an outage
+doesn't lose events.
+
+```go
+import "time"
+
+_, err = api.CreateOutput(&webhookrelay.Output{
+	BucketID:    bucket.ID,
+	Name:        "billing",
+	Destination: "https://api.internal.example.com/webhooks",
+	Durability: &webhookrelay.DurabilityConfig{
+		Enabled:      true,
+		Schedule:     "long",           // "seconds", "medium", "long" or "custom"
+		Deadline:     30 * 24 * time.Hour, // give up after 30 days
+		HandoffAfter: 15 * time.Minute,    // move to durable retries after 15m of failures
+	},
+})
+```
+
+### Throttling
+
+Cap how fast webhooks are delivered to a fragile or rate-limited destination.
+Queue and release at a fixed **rate**, or bound **concurrency**.
+
+```go
+// Rate limit: at most 10 deliveries per minute.
+_, err = api.CreateOutput(&webhookrelay.Output{
+	BucketID:    bucket.ID,
+	Name:        "rate-limited-api",
+	Destination: "https://api.example.com/webhooks",
+	Throttle: &webhookrelay.ThrottleConfig{
+		Enabled:  true,
+		Mode:     webhookrelay.ThrottleModeRate,
+		Rate:     10,
+		Interval: webhookrelay.ThrottleIntervalMinute,
+	},
+})
+
+// Or bound in-flight concurrency instead:
+throttle := &webhookrelay.ThrottleConfig{
+	Enabled:       true,
+	Mode:          webhookrelay.ThrottleModeConcurrency,
+	MaxConcurrent: 5,
+	MaxQueueDepth: 1000, // reject with HTTP 429 once the queue is full
+}
+_ = throttle
+```
+
+## More capabilities
+
+The client covers the rest of the Webhook Relay API too:
+
+- **Transformation functions** (JavaScript / Lua) to reshape webhooks in flight —
+  `CreateFunction`, `SetFunctionConfigurationVariable`, `InvokeFunction`. Attach one
+  to an input or output via `FunctionID`.
+- **Recurring webhooks** on a cron schedule — `CreateCron`.
+- **Tunnels** to expose a local service over a public hostname — `CreateTunnel`.
+- **Service connections** (GCP / AWS / Azure) plus cloud event **inputs** (Pub/Sub,
+  S3, SQS, SNS) and **outputs** (Pub/Sub, GCS, S3, SQS, SNS, Discord, Slack).
+- **Email-to-webhook** — an inbound email address that relays mail through a bucket
+  (`CreateServiceConnectionInput` with type `email`).
+- **Notification integrations** — `CreateIntegration`, `AddIntegrationBucket`.
+- **Routing rules**, retries, TLS controls, custom domains, and webhook logs.
+
+## Client options
+
+`New` / `NewWithAPIKey` accept functional options:
+
+```go
+api, err := webhookrelay.NewWithAPIKey(os.Getenv("RELAY_API_KEY"),
+	webhookrelay.WithUserAgent("my-app/1.2.3"),
+	webhookrelay.WithRetryPolicy(3, 1, 30), // retries, min/max backoff (seconds)
+)
+```
+
+Available options: `WithHTTPClient`, `WithAPIEndpointURL`, `WithHeaders`,
+`WithRetryPolicy`, `WithUserAgent`, `WithLogger`.
+
+## License
+
+See [LICENSE](LICENSE).

--- a/integration_test.go
+++ b/integration_test.go
@@ -66,6 +66,16 @@ func TestIntegrationBucketLifecycle(t *testing.T) {
 		t.Fatalf("GetBucket returned %q, want %q", got.ID, bucket.ID)
 	}
 
+	// Polling: listing logs for the bucket must succeed (empty for a fresh
+	// bucket). Exercises the required bucket query parameter.
+	logs, err := client.ListWebhookLogs(&WebhookLogsListOptions{BucketID: bucket.ID, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListWebhookLogs: %v", err)
+	}
+	if logs == nil {
+		t.Fatalf("ListWebhookLogs returned nil response")
+	}
+
 	// --- Input ---
 	t.Run("input", func(t *testing.T) {
 		input, err := client.CreateInput(&Input{

--- a/webhook_logs.go
+++ b/webhook_logs.go
@@ -116,10 +116,24 @@ type WebhookLogsResponse struct {
 	Offset int    `json:"offset"`
 }
 
-// ListWebhookLogs lists webhook logs for an account
+// ListWebhookLogs lists webhook logs for a bucket. BucketID is required; the
+// remaining WebhookLogsListOptions fields (Status, From, To, Limit, Offset)
+// filter and paginate the results. Poll this endpoint to consume received
+// webhooks without forwarding them.
 func (api *API) ListWebhookLogs(options *WebhookLogsListOptions) (*WebhookLogsResponse, error) {
+	if options == nil {
+		options = &WebhookLogsListOptions{}
+	}
+	if options.BucketID == "" {
+		return nil, errors.New("BucketID is required to list webhook logs")
+	}
 
-	resp, err := api.makeRequest(http.MethodGet, "/logs", nil)
+	path := "/logs"
+	if q := getQuery(options); q != "" {
+		path += "?" + q
+	}
+
+	resp, err := api.makeRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, errMakeRequestError)
 	}

--- a/webhook_logs_test.go
+++ b/webhook_logs_test.go
@@ -1,7 +1,58 @@
 //go:generate jsonenums -type=RequestStatus
 package webhookrelay
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestListWebhookLogsAppliesQuery verifies the filter/pagination options reach
+// the request as query parameters (a regression guard: they were previously
+// built but never attached to the URL).
+func TestListWebhookLogsAppliesQuery(t *testing.T) {
+	var gotPath, gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotQuery = r.URL.Path, r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"total":0,"limit":50,"offset":0}`))
+	}))
+	defer server.Close()
+
+	client, err := New("k", "s", WithAPIEndpointURL(server.URL))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := client.ListWebhookLogs(&WebhookLogsListOptions{
+		BucketID: "bucket-1",
+		Status:   RequestStatusSent,
+		Limit:    50,
+	}); err != nil {
+		t.Fatalf("ListWebhookLogs: %v", err)
+	}
+
+	if gotPath != "/logs" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	for _, want := range []string{"bucket=bucket-1", "status=sent", "limit=50"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query %q missing %q", gotQuery, want)
+		}
+	}
+}
+
+// TestListWebhookLogsRequiresBucket guards the client-side validation.
+func TestListWebhookLogsRequiresBucket(t *testing.T) {
+	client, err := New("k", "s")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := client.ListWebhookLogs(&WebhookLogsListOptions{}); err == nil {
+		t.Fatal("expected error when BucketID is empty")
+	}
+}
 
 func Test_getQuery(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
## Summary

Rewrites the README to demonstrate the main Webhook Relay features from Go, and fixes a real bug in `ListWebhookLogs` found while writing the polling example.

### README
Feature-focused sections, each with a copy-pasteable snippet:
- **Internal webhooks** — deliver behind a firewall via the `relay` agent (`Output.Internal`)
- **WebSocket streaming** — `Bucket.Stream` + `wss://…/v1/socket`, responding via `UpdateWebhookLog`
- **Polling** — `ListWebhookLogs` loop over a bucket
- **Durable delivery** — `Output.Durability`
- **Throttling** — `Output.Throttle` (rate + concurrency)
- Plus a quickstart, features overview (functions, crons, tunnels, service connections, email-to-webhook, integrations) and client options.

Every snippet was type-checked against the SDK before committing.

### Bug fix — `ListWebhookLogs`
It built a query string via `getQuery()` but never attached it to the request, so:
- the **required** `bucket` parameter was never sent → the call always failed with `400 "bucket ID is required"`;
- `Status`/`From`/`To`/`Limit`/`Offset` filters were silently ignored.

Now it applies the query and validates `BucketID`. Covered by `TestListWebhookLogsAppliesQuery` / `TestListWebhookLogsRequiresBucket` and a live smoke check in the integration test.

### Also
Updated the repo description and topics.

## Verification
`go build`/`go vet` clean; full suite green (live tests skip without creds; run against the live API in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The `ListWebhookLogs` fix changes runtime behavior (previously broken API calls; empty `BucketID` now fails client-side), which could break callers that omitted `BucketID` even though the API already required it.
> 
> **Overview**
> **README** is expanded into a feature-oriented guide: quickstart, internal/`relay` forwarding, WebSocket streaming, **polling** via `ListWebhookLogs`, durable delivery, throttling, plus a broader API overview and client options (badges/links updated).
> 
> **`ListWebhookLogs`** now appends `getQuery()` to the GET path so `bucket` and filters (`status`, time range, `limit`/`offset`) reach the API, and returns a client error when `BucketID` is missing. Docs on the method match that contract.
> 
> **Tests:** httptest regression for query params and empty-bucket validation; integration lifecycle calls `ListWebhookLogs` on a fresh bucket.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb802f5115638a068edaf3e70e2bce09219bd2dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->